### PR TITLE
Enabling the Gateway API for cloud Armor

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -8,24 +8,23 @@ terraform {
   # This module is now only being tested with Terraform 1.0.x. However, to make upgrading easier, we are setting
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 1.0.x code.
-  required_version = ">= 0.12.26"
-
+  required_version = ">= 0.12.26, <= 1.3.7"
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.43.0"
+      version = "~> 3.43.0 ,<= 6.0.0"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.43.0"
+      version = "~> 3.43.0, <= 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"
-      version = "~> 1.7.0"
+      version = "~> 1.7.0, <= 2.0.0"
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 1.1.1"
+      version = "~> 1.1.1, <=2.12.1"
     }
   }
 }

--- a/modules/gke-cluster/main.tf
+++ b/modules/gke-cluster/main.tf
@@ -7,7 +7,7 @@ terraform {
   # This module is now only being tested with Terraform 1.0.x. However, to make upgrading easier, we are setting
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 1.0.x code.
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.26, <= 1.3.7"
 }
 
 locals {
@@ -155,6 +155,9 @@ resource "google_container_cluster" "cluster" {
     channel = var.release_channel
   }
 
+  gateway_api_config {
+    channel = var.enable_gateway_api
+  }
 
   lifecycle {
     ignore_changes = [

--- a/modules/gke-cluster/variables.tf
+++ b/modules/gke-cluster/variables.tf
@@ -273,3 +273,9 @@ variable "dataset_id" {
   type        = string
   default     = "cluster_resource_usage"
 }
+
+variable "enable_gateway_api" {
+  description = "Gateaway API is a managed API Gateway for Google Cloud services. https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/container_cluster#nested_gateway_api_config IN order to enable it use CHANNEL_STANDARD"
+  type        = string
+  default     = "CHANNEL_DISABLED"
+}

--- a/modules/gke-service-account/main.tf
+++ b/modules/gke-service-account/main.tf
@@ -2,7 +2,7 @@ terraform {
   # This module is now only being tested with Terraform 1.0.x. However, to make upgrading easier, we are setting
   # 0.12.26 as the minimum version, as that version added support for required_providers with source URLs, making it
   # forwards compatible with 1.0.x code.
-  required_version = ">= 0.12.26"
+  required_version = ">= 0.12.26, <= 1.3.7"
 }
 
 # ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
## [PLT-732](https://ultimateai.atlassian.net/browse/PLT-732)

- Enabling the gateway api so as to enforce Cloud Armor policies 

[PLT-732]: https://ultimateai.atlassian.net/browse/PLT-732?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ